### PR TITLE
Fix oversights, critical bug for Garrison

### DIFF
--- a/SAGE/Games/Kane's Wrath/Modules/GarrisonContain.xml
+++ b/SAGE/Games/Kane's Wrath/Modules/GarrisonContain.xml
@@ -18,7 +18,7 @@
 		<EntryInheritance
 			id="base"
 			AssetType="OpenContainModuleData" />
-		<EntryRelocation
+		<Entry
 			id="InitialRoster"
 			AssetType="InitialRoster" />
 		<Entry

--- a/SAGE/Games/Kane's Wrath/Modules/ProductionUpdate.xml
+++ b/SAGE/Games/Kane's Wrath/Modules/ProductionUpdate.xml
@@ -105,13 +105,11 @@
 		<EntryWeakReference
 			id="BonusForType"
 			AssetType="GameObject"
-			IsAttribute="true"
-			Default="0" />
+			IsAttribute="true" />
 		<EntryReference
 			id="SpeedBonusAudioLoop"
 			AssetType="AudioEventInfo"
-			IsAttribute="true"
-			Default="0" />
+			IsAttribute="true" />
 		<Entry
 			id="Type"
 			AssetType="ProductionQueueType"


### PR DESCRIPTION
xas:byValue="true" was on the InitialRoster complexType instead of in the element